### PR TITLE
Require serializer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,9 @@
     "olvlvl/composer-attribute-collector": "^1.1",
     "php": ">=8.2",
     "php-di/php-di": "^7.0",
-    "psr/container": "2.0.2"
+    "psr/container": "2.0.2",
+    "symfony/property-access": "^6.2",
+    "symfony/serializer": "^6.2"
   },
   "require-dev": {
     "infection/infection": "^0.26.19",


### PR DESCRIPTION
The serializer is required with the app thing.

We really need to refactor this into separate packages... but that probably won't happen for awhile.