### PR TITLE
Allow replacing nodes

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -79,6 +79,11 @@ class App
 			$router = new MagicRouter($this->container, $this->indexClass);
 			$response = $router->go();
 
+			if($response === null) {
+				http_response_code(404);
+				return;
+			}
+
 			/**
 			 * @var Queue $caching
 			 */
@@ -96,16 +101,18 @@ class App
 				}
 			}
 
+			$this->setHeader('Content-Length', (string)strlen($response));
+
 			echo $response;
 		} catch (InvalidRequest $e) {
 			http_response_code(400);
 			$this->container->get(LoggerInterface::class)->warning('Invalid request', ['exception' => $e]);
+			return;
 		} catch (NotAuthorized $e) {
 			http_response_code(401);
 			$this->container->get(LoggerInterface::class)->warning('Not authorized', ['exception' => $e]);
+			return;
 		}
-
-		http_response_code(404);
 	}
 
 	protected function setHeader(string $name, string $value): void

--- a/src/Template/CompiledComponent.php
+++ b/src/Template/CompiledComponent.php
@@ -3,7 +3,7 @@
 namespace Bottledcode\SwytchFramework\Template;
 
 use Bottledcode\SwytchFramework\Template\Interfaces\BeforeRenderInterface;
-use Psr\Container\ContainerInterface;
+use DI\FactoryInterface;
 use ReflectionClass;
 
 readonly class CompiledComponent
@@ -13,12 +13,12 @@ readonly class CompiledComponent
 
 	/**
 	 * @param class-string $component
-	 * @param ContainerInterface $container
+	 * @param FactoryInterface $container
 	 * @param Compiler $compiler
 	 */
 	public function __construct(
 		public string $component,
-		private ContainerInterface $container,
+		private FactoryInterface $container,
 		private Compiler $compiler
 	) {
 	}

--- a/src/Template/CompiledComponent.php
+++ b/src/Template/CompiledComponent.php
@@ -33,7 +33,7 @@ readonly class CompiledComponent
 	public function compile(array $attributes = []): \DOMDocument|\DOMDocumentFragment
 	{
 		// we are about to render
-		$component = $this->container->get($this->component);
+		$component = $this->container->make($this->component);
 		if ($component instanceof BeforeRenderInterface) {
 			$component->aboutToRender($attributes);
 		}

--- a/src/Template/Interfaces/RemovePassedAttributes.php
+++ b/src/Template/Interfaces/RemovePassedAttributes.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Bottledcode\SwytchFramework\Template\Interfaces;
+
+interface RemovePassedAttributes
+{
+	public static function removePassedAttributes(): bool;
+}

--- a/src/Template/Interfaces/ReplacesHtml.php
+++ b/src/Template/Interfaces/ReplacesHtml.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Bottledcode\SwytchFramework\Template\Interfaces;
+
+interface ReplacesHtml
+{
+    public function replaceTag(): bool;
+}

--- a/src/Template/TreeBuilder.php
+++ b/src/Template/TreeBuilder.php
@@ -154,7 +154,7 @@ class TreeBuilder extends DOMTreeBuilder
 
 			// we need to remove the attributes from the component
 			$removeAttributes = true;
-			if (method_exists($current, 'removePassedAttributes')) {
+			if (method_exists($this->components[$name], 'removePassedAttributes')) {
 				$removeAttributes = ($this->components[$name])::removePassedAttributes();
 			}
 			if ($removeAttributes) {

--- a/src/Template/TreeBuilder.php
+++ b/src/Template/TreeBuilder.php
@@ -186,7 +186,20 @@ class TreeBuilder extends DOMTreeBuilder
 					$component->renderedComponent,
 					'replaceTag'
 				) && $component->renderedComponent?->replaceTag()) {
-				$current->replaceWith($content);
+				$nodes = [];
+				$last = null;
+				foreach ($content->childNodes as $node) {
+					$nodes[] = $node;
+					if ($node instanceof \DOMElement || $node instanceof \DOMDocumentFragment) {
+						$last = $node;
+					}
+				}
+				if ($last === null) {
+					throw new \LogicException('No element found in component content.');
+				}
+				$this->current = $last;
+				$current->before(...$nodes);
+				$current->remove();
 			} elseif ($content->childElementCount > 0) {
 				$current->appendChild($content);
 			}

--- a/src/Template/TreeBuilder.php
+++ b/src/Template/TreeBuilder.php
@@ -153,8 +153,14 @@ class TreeBuilder extends DOMTreeBuilder
 			$usedAttributes = $component->getUsedAttributes();
 
 			// we need to remove the attributes from the component
-			foreach (array_intersect_key($attributes, $usedAttributes) as $key => $value) {
-				$current->removeAttribute($key);
+			$removeAttributes = true;
+			if (method_exists($current, 'removePassedAttributes')) {
+				$removeAttributes = ($this->components[$name])::removePassedAttributes();
+			}
+			if ($removeAttributes) {
+				foreach (array_intersect_key($attributes, $usedAttributes) as $key => $value) {
+					$current->removeAttribute($key);
+				}
 			}
 
 			$blobber = $this->container->get(EscaperInterface::class);

--- a/src/Template/TreeBuilder.php
+++ b/src/Template/TreeBuilder.php
@@ -187,9 +187,7 @@ class TreeBuilder extends DOMTreeBuilder
 					'replaceTag'
 				) && $component->renderedComponent?->replaceTag()) {
 				$current->replaceWith($content);
-			}
-
-			if ($content->childElementCount > 0) {
+			} elseif ($content->childElementCount > 0) {
 				$current->appendChild($content);
 			}
 


### PR DESCRIPTION
Allows a component to specify a `replaceTag():bool` method to replace the parent tag with. This will break everything, but can be useful. I guess we'll find out.