### PR TITLE
Refactor router component

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -76,6 +76,7 @@
     <inspection_tool class="PhpNewClassMissingParameterListInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PhpSeparateElseIfInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PhpStanGlobal" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
+    <inspection_tool class="PhpTernaryExpressionCanBeReplacedWithConditionInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PhpTraitsUseListInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="PhpVarUsageInspection" enabled="true" level="WEAK WARNING" enabled_by_default="true" />
     <inspection_tool class="SecurityAdvisoriesInspection" enabled="true" level="WARNING" enabled_by_default="true">

--- a/src/Router/MagicRouter.php
+++ b/src/Router/MagicRouter.php
@@ -9,6 +9,7 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 
 readonly class MagicRouter
@@ -39,6 +40,9 @@ readonly class MagicRouter
 
 		try {
 			$request = $hooks->preprocess($request, $requestType);
+			if (method_exists($this->container, 'set')) {
+				$this->container->set(ServerRequestInterface::class, $request);
+			}
 			$response = $hooks->process($request, $requestType, $response);
 			$response = $hooks->postProcess($response, $requestType);
 		} catch (Throwable $e) {

--- a/src/Template/CompiledComponent.php
+++ b/src/Template/CompiledComponent.php
@@ -89,7 +89,7 @@ readonly class CompiledComponent
 
 		$this->renderedComponent = $component;
 
-		return $this->compiler->compile($rendered, $children);
+		return $this->compiler->compile($rendered, $children, $this);
 	}
 
 	public function renderAttributes(): array

--- a/src/Template/CompiledComponent.php
+++ b/src/Template/CompiledComponent.php
@@ -19,7 +19,7 @@ use ReflectionClass;
 use ReflectionException;
 use RuntimeException;
 
-readonly class CompiledComponent
+class CompiledComponent
 {
 	public mixed $renderedComponent;
 
@@ -30,9 +30,9 @@ readonly class CompiledComponent
 	 * @param array<string> $attributes
 	 */
 	public function __construct(
-		public string $component,
-		private FactoryInterface $container,
-		private Compiler $compiler,
+		public readonly string $component,
+		private readonly FactoryInterface $container,
+		private readonly Compiler $compiler,
 		public array $attributes = []
 	) {
 	}
@@ -83,6 +83,8 @@ readonly class CompiledComponent
 				}
 			}
 		}
+
+		$this->attributes = $attributes;
 
 		// render the component
 		$rendered = $component->render(...$attributes);

--- a/src/Template/Compiler.php
+++ b/src/Template/Compiler.php
@@ -143,7 +143,7 @@ final class Compiler
 	 * @throws Exception
 	 * @throws NotFoundExceptionInterface
 	 */
-	public function compile(string $html, callable|null $children = null): DOMDocument|DOMDocumentFragment
+	public function compile(string $html, callable|null $children = null, CompiledComponent|null $component = null): DOMDocument|DOMDocumentFragment
 	{
 		$isFragment = !str_contains($html, '<html');
 
@@ -155,7 +155,8 @@ final class Compiler
 			$this->logger,
 			$isFragment,
 			[...self::OPTIONS, 'target_document' => $this->doc],
-			$children
+			$children,
+			$component
 		);
 		if ($this->doc === null) {
 			$this->doc = $events->document();

--- a/src/Template/Functional/DataProvider.php
+++ b/src/Template/Functional/DataProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Bottledcode\SwytchFramework\Template\Functional;
+
+interface DataProvider
+{
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function provideAttributes(): array;
+
+	public function provideValues(string $value): mixed;
+}

--- a/src/Template/Functional/DefaultRoute.php
+++ b/src/Template/Functional/DefaultRoute.php
@@ -7,11 +7,11 @@ use Bottledcode\SwytchFramework\Template\Attributes\Component;
 #[Component('DefaultRoute')]
 class DefaultRoute extends Route
 {
-	public function render(string $render, string|null $path = null, string|null $method = null): string
+	public function render(string|null $path = null, string|null $method = null): string
 	{
 		if ($this->foundRoute()) {
 			return '';
 		}
-		return $render;
+		return "<children></children>";
 	}
 }

--- a/src/Template/LazyTreeBuilder.php
+++ b/src/Template/LazyTreeBuilder.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Bottledcode\SwytchFramework\Template;
+
+use Bottledcode\SwytchFramework\Template\Functional\DataProvider;
+use Bottledcode\SwytchFramework\Template\Interfaces\AuthenticationServiceInterface;
+use Bottledcode\SwytchFramework\Template\Interfaces\StateProviderInterface;
+use DI\FactoryInterface;
+use Masterminds\HTML5\Parser\DOMTreeBuilder;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
+use Psr\Log\LoggerInterface;
+
+class LazyTreeBuilder extends DOMTreeBuilder
+{
+	private static int $id = 0;
+	private array $componentStack = [];
+	private readonly StateProviderInterface $stateProvider;
+	private readonly AuthenticationServiceInterface|null $authenticationService;
+	private array $childParents = [];
+	private array $delayStack = [];
+
+	private array|null $delayStackPointer = null;
+
+	private array $dataProviders = [];
+
+	/**
+	 * @param ContainerInterface $container
+	 * @param array<string, class-string> $components
+	 * @param bool $isFragment
+	 * @param array<mixed> $options
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 */
+	public function __construct(
+		private readonly ContainerInterface $container,
+		private readonly array $components,
+		private readonly LoggerInterface $logger,
+		bool $isFragment = false,
+		array $options = [],
+		private readonly \Closure|null $children = null,
+	) {
+		parent::__construct($isFragment, $options);
+		$this->stateProvider = $this->container->get(StateProviderInterface::class);
+		try {
+			$this->authenticationService = $this->container->get(AuthenticationServiceInterface::class);
+		} catch (NotFoundExceptionInterface|ContainerExceptionInterface) {
+			$this->authenticationService = null;
+		}
+	}
+
+	/**
+	 * @param string $msg
+	 * @param int $line
+	 * @param int $col
+	 * @return void
+	 */
+	public function parseError($msg, $line = 0, $col = 0)
+	{
+		$this->logger->notice('HTML parse error: ' . $msg, compact('line', 'col'));
+		parent::parseError($msg, $line, $col);
+	}
+
+	/**
+	 * @param string $name
+	 * @param array<string> $attributes
+	 * @param bool $selfClosing
+	 * @return int
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 * @throws \DOMException
+	 */
+	public function startTag($name, $attributes = array(), $selfClosing = false): int
+	{
+		if ($selfClosing) {
+			$this->pushComponent($name, $attributes);
+		}
+
+		$tag = parent::startTag($name, $attributes, $selfClosing);
+
+		if (!$selfClosing) {
+			$this->pushComponent($name, $attributes);
+		}
+
+		return $tag;
+	}
+
+	private function pushComponent(string $name, array $attributes): void
+	{
+		$component = $this->components[$name] ?? null;
+		if ($component) {
+			$this->componentStack[$name] = new CompiledComponent(
+				$component,
+				$this->container->get(FactoryInterface::class),
+				$this->container->get(Compiler::class),
+				$attributes
+			);
+
+			// in a weird quirk of php, this results in appending a new array to the delay stack and they are the same variable.
+			$this->delayStackPointer = &$this->delayStack[];
+			$this->delayStackPointer = [];
+
+			// consume children
+			$this->childParents[] = $this->current;
+			$this->current = $this->document()->createDocumentFragment();
+
+			// fragment must be attached to the document in order to be kept. See https://bugs.php.net/bug.php?id=39593
+			$this->document()->append($this->current);
+		}
+	}
+
+	/**
+	 * @param string $name
+	 * @return void
+	 */
+	public function endTag($name): void
+	{
+		parent::endTag($name);
+	}
+
+	public function autoclose($tagName): bool
+	{
+		return $this->render($tagName);
+	}
+
+	private function render(string $name): bool
+	{
+		$component = end($this->componentStack) ?: null;
+		if ($component && key($this->componentStack) === $name) {
+			$children = $this->current instanceof \DOMDocumentFragment ? iterator_to_array(
+				$this->current->childNodes
+			) : [];
+			$this->current = array_pop($this->childParents) ?: throw new \LogicException('No parent to render to');
+
+			if (count($this->componentStack) === 1) {
+				// we are the parent component and should render ourselves
+
+				$this->decorateComponent(end($this->componentStack));
+				$renderedChildren = false;
+				$children = empty($children) ? null : function () use (&$renderedChildren, $children) {
+					$renderedChildren = true;
+					foreach ($children as $child) {
+						$this->current->parentNode->appendChild($child);
+					}
+					$parent = $this->current->parentNode;
+					$parent->removeChild($this->current);
+					$this->current = $parent;
+					return true;
+				};
+
+				try {
+					$compiledDom = $component->compile(
+						$consumableAttr = $component->renderAttributes(),
+						$children,
+						$this->dataProviders
+					);
+					if($component->renderedComponent instanceof DataProvider) {
+						$this->dataProviders[] = $component->renderedComponent;
+					}
+				} catch (\Throwable $e) {
+					throw new \RuntimeException('Error compiling component ' . $component->component, 0, $e);
+				}
+				if ($compiledDom->childElementCount > 0) {
+					$this->current->appendChild($compiledDom);
+				}
+				if ($this->current instanceof \DOMElement) {
+					foreach ($consumableAttr as $attr => $value) {
+						$this->current->removeAttribute($attr);
+					}
+				}
+				while (count($this->delayStackPointer) && $renderedChildren) {
+					// store the previous state
+					$toRender = array_pop($this->delayStackPointer);
+					$actualCurrent = $this->current;
+					$previousCurrent = $toRender[2];
+					$previousStack = $this->componentStack;
+					$this->componentStack = [$previousCurrent->tagName => $toRender[0]];
+					$this->childParents[] = $toRender[2];
+					$this->current = $previousCurrent;
+
+					// now render the state
+					$this->render($previousCurrent->tagName);
+
+					// restore state
+					$this->current = $actualCurrent;
+					$this->componentStack = $previousStack;
+				}
+
+				if (is_subclass_of($component->component, DataProvider::class)) {
+					array_pop($this->dataProviders);
+				}
+			} else {
+				$this->delayStackPointer[] = [$component, $children, $this->current];
+			}
+
+			array_pop($this->componentStack);
+		}
+
+		if ($name === 'children' && is_callable($this->children)) {
+			($this->children)->call($this);
+			return true;
+		}
+
+		return parent::autoclose($name);
+	}
+
+	private function decorateComponent(CompiledComponent $component): void
+	{
+		if (method_exists($component->component, 'skipHxProcessing')) {
+			$skipHxProcessing = [$component->component, 'skipHxProcessing'];
+			if ($skipHxProcessing()) {
+				return;
+			}
+		}
+		$id = substr(md5((string)self::$id++), 0, 8);
+		if ($this->current instanceof \DOMElement && !$this->current->hasAttribute('id')) {
+			$this->current->setAttribute('id', $id);
+		}
+	}
+}

--- a/src/Template/LazyTreeBuilder.php
+++ b/src/Template/LazyTreeBuilder.php
@@ -5,31 +5,58 @@ namespace Bottledcode\SwytchFramework\Template;
 use Bottledcode\SwytchFramework\Template\Functional\DataProvider;
 use Bottledcode\SwytchFramework\Template\Interfaces\AuthenticationServiceInterface;
 use Bottledcode\SwytchFramework\Template\Interfaces\StateProviderInterface;
+use Closure;
 use DI\FactoryInterface;
+use DOMDocumentFragment;
+use DOMElement;
+use DOMNode;
+use LogicException;
 use Masterminds\HTML5\Parser\DOMTreeBuilder;
 use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\ContainerInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Throwable;
 
 class LazyTreeBuilder extends DOMTreeBuilder
 {
 	private static int $id = 0;
+
+	/**
+	 * @var array<CompiledComponent>
+	 */
 	private array $componentStack = [];
+
 	private readonly StateProviderInterface $stateProvider;
 	private readonly AuthenticationServiceInterface|null $authenticationService;
+	/**
+	 * @var array<DOMNode>
+	 */
 	private array $childParents = [];
+
+	/**
+	 * @var array<array<CompiledComponent>>
+	 */
 	private array $delayStack = [];
 
+	/**
+	 * @var array<CompiledComponent>
+	 */
 	private array|null $delayStackPointer = null;
 
+	/**
+	 * @var array<DataProvider>
+	 */
 	private array $dataProviders = [];
 
 	/**
 	 * @param ContainerInterface $container
 	 * @param array<string, class-string> $components
+	 * @param LoggerInterface $logger
 	 * @param bool $isFragment
 	 * @param array<mixed> $options
+	 * @param Closure|null $children
 	 * @throws ContainerExceptionInterface
 	 * @throws NotFoundExceptionInterface
 	 */
@@ -39,7 +66,7 @@ class LazyTreeBuilder extends DOMTreeBuilder
 		private readonly LoggerInterface $logger,
 		bool $isFragment = false,
 		array $options = [],
-		private readonly \Closure|null $children = null,
+		private readonly Closure|null $children = null,
 	) {
 		parent::__construct($isFragment, $options);
 		$this->stateProvider = $this->container->get(StateProviderInterface::class);
@@ -56,7 +83,7 @@ class LazyTreeBuilder extends DOMTreeBuilder
 	 * @param int $col
 	 * @return void
 	 */
-	public function parseError($msg, $line = 0, $col = 0)
+	public function parseError($msg, $line = 0, $col = 0): void
 	{
 		$this->logger->notice('HTML parse error: ' . $msg, compact('line', 'col'));
 		parent::parseError($msg, $line, $col);
@@ -67,9 +94,6 @@ class LazyTreeBuilder extends DOMTreeBuilder
 	 * @param array<string> $attributes
 	 * @param bool $selfClosing
 	 * @return int
-	 * @throws ContainerExceptionInterface
-	 * @throws NotFoundExceptionInterface
-	 * @throws \DOMException
 	 */
 	public function startTag($name, $attributes = array(), $selfClosing = false): int
 	{
@@ -86,6 +110,13 @@ class LazyTreeBuilder extends DOMTreeBuilder
 		return $tag;
 	}
 
+	/**
+	 * @param string $name
+	 * @param array<string> $attributes
+	 * @return void
+	 * @throws ContainerExceptionInterface
+	 * @throws NotFoundExceptionInterface
+	 */
 	private function pushComponent(string $name, array $attributes): void
 	{
 		$component = $this->components[$name] ?? null;
@@ -128,10 +159,10 @@ class LazyTreeBuilder extends DOMTreeBuilder
 	{
 		$component = end($this->componentStack) ?: null;
 		if ($component && key($this->componentStack) === $name) {
-			$children = $this->current instanceof \DOMDocumentFragment ? iterator_to_array(
+			$children = $this->current instanceof DOMDocumentFragment ? iterator_to_array(
 				$this->current->childNodes
 			) : [];
-			$this->current = array_pop($this->childParents) ?: throw new \LogicException('No parent to render to');
+			$this->current = array_pop($this->childParents) ?: throw new LogicException('No parent to render to');
 
 			if (count($this->componentStack) === 1) {
 				// we are the parent component and should render ourselves
@@ -146,11 +177,11 @@ class LazyTreeBuilder extends DOMTreeBuilder
 						$children,
 						$this->dataProviders
 					);
-					if($component->renderedComponent instanceof DataProvider) {
+					if ($component->renderedComponent instanceof DataProvider) {
 						$this->dataProviders[] = $component->renderedComponent;
 					}
-				} catch (\Throwable $e) {
-					throw new \RuntimeException('Error compiling component ' . $component->component, 0, $e);
+				} catch (Throwable $e) {
+					throw new RuntimeException('Error compiling component ' . $component->component, 0, $e);
 				}
 				$this->attachToDom($compiledDom, $consumableAttr);
 				$this->renderChildren($renderedChildren);
@@ -165,23 +196,19 @@ class LazyTreeBuilder extends DOMTreeBuilder
 			array_pop($this->componentStack);
 		}
 
-		if($this->replaceChildren($name)) {
+		if ($this->replaceChildren($name)) {
 			return true;
 		}
 
 		return parent::autoclose($name);
 	}
 
-	private function replaceChildren(string $name): true|null {
-		if ($name === 'children' && is_callable($this->children)) {
-			($this->children)->call($this);
-			return true;
-		}
-		return null;
-	}
-
-	private function decorateComponent(CompiledComponent $component): void
+	private function decorateComponent(CompiledComponent|false $component): void
 	{
+		if($component === false) {
+			return;
+		}
+
 		if (method_exists($component->component, 'skipHxProcessing')) {
 			$skipHxProcessing = [$component->component, 'skipHxProcessing'];
 			if ($skipHxProcessing()) {
@@ -189,8 +216,47 @@ class LazyTreeBuilder extends DOMTreeBuilder
 			}
 		}
 		$id = substr(md5((string)self::$id++), 0, 8);
-		if ($this->current instanceof \DOMElement && !$this->current->hasAttribute('id')) {
+		if ($this->current instanceof DOMElement && !$this->current->hasAttribute('id')) {
 			$this->current->setAttribute('id', $id);
+		}
+	}
+
+	/**
+	 * @param array<DOMNode> $children
+	 * @param false $renderedChildren
+	 * @return callable|null
+	 */
+	public function extractChildrenCallable(array $children, bool &$renderedChildren): callable|null
+	{
+		if (empty($children)) {
+			return null;
+		}
+		return function () use (&$renderedChildren, $children) {
+			$renderedChildren = true;
+			foreach ($children as $child) {
+				$this->current->parentNode->appendChild($child);
+			}
+			$parent = $this->current->parentNode;
+			$parent->removeChild($this->current);
+			$this->current = $parent;
+			return true;
+		};
+	}
+
+	/**
+	 * @param DOMDocumentFragment $compiledDom
+	 * @param array<string> $consumableAttr
+	 * @return void
+	 */
+	public function attachToDom(DOMDocumentFragment $compiledDom, array $consumableAttr): void
+	{
+		if ($compiledDom->childElementCount > 0) {
+			$this->current->appendChild($compiledDom);
+		}
+		if ($this->current instanceof DOMElement) {
+			foreach ($consumableAttr as $attr => $value) {
+				$this->current->removeAttribute($attr);
+			}
 		}
 	}
 
@@ -219,42 +285,12 @@ class LazyTreeBuilder extends DOMTreeBuilder
 		}
 	}
 
-	/**
-	 * @param $compiledDom
-	 * @param $consumableAttr
-	 * @return void
-	 */
-	public function attachToDom($compiledDom, $consumableAttr): void
+	private function replaceChildren(string $name): true|null
 	{
-		if ($compiledDom->childElementCount > 0) {
-			$this->current->appendChild($compiledDom);
-		}
-		if ($this->current instanceof \DOMElement) {
-			foreach ($consumableAttr as $attr => $value) {
-				$this->current->removeAttribute($attr);
-			}
-		}
-	}
-
-	/**
-	 * @param array<\DOMNode> $children
-	 * @param false $renderedChildren
-	 * @return callable|null
-	 */
-	public function extractChildrenCallable(array $children, bool &$renderedChildren): callable|null
-	{
-		if (empty($children)) {
-			return null;
-		}
-		return function () use (&$renderedChildren, $children) {
-			$renderedChildren = true;
-			foreach ($children as $child) {
-				$this->current->parentNode->appendChild($child);
-			}
-			$parent = $this->current->parentNode;
-			$parent->removeChild($this->current);
-			$this->current = $parent;
+		if ($name === 'children' && is_callable($this->children)) {
+			($this->children)->call($this);
 			return true;
-		};
+		}
+		return null;
 	}
 }

--- a/src/Template/LazyTreeBuilder.php
+++ b/src/Template/LazyTreeBuilder.php
@@ -10,6 +10,7 @@ use Bottledcode\SwytchFramework\Template\Interfaces\EscaperInterface;
 use Bottledcode\SwytchFramework\Template\Interfaces\StateProviderInterface;
 use Closure;
 use DI\FactoryInterface;
+use DOMDocument;
 use DOMDocumentFragment;
 use DOMElement;
 use DOMNode;
@@ -280,6 +281,9 @@ class LazyTreeBuilder extends DOMTreeBuilder
 				} catch (Throwable $e) {
 					throw new RuntimeException('Error compiling component ' . $component->component, 0, $e);
 				}
+				if (method_exists($this->components[$name], 'removePassedAttributes') && !($this->components[$name])::removePassedAttributes()) {
+					$consumableAttr = [];
+				}
 				$this->attachToDom($compiledDom, $consumableAttr);
 				$this->renderChildren($renderedChildren);
 
@@ -345,11 +349,11 @@ class LazyTreeBuilder extends DOMTreeBuilder
 	}
 
 	/**
-	 * @param DOMDocumentFragment $compiledDom
+	 * @param DOMDocument|DOMDocumentFragment $compiledDom
 	 * @param array<string> $consumableAttr
 	 * @return void
 	 */
-	public function attachToDom(DOMDocumentFragment $compiledDom, array $consumableAttr): void
+	public function attachToDom(DOMDocument|DOMDocumentFragment $compiledDom, array $consumableAttr): void
 	{
 		if ($compiledDom->childElementCount > 0) {
 			$this->current->appendChild($compiledDom);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -17,6 +17,7 @@ it('renders correctly', function () {
 		targetMethods: []
 	));
 	$compiler = new Compiler($container);
+	$container->set(Compiler::class, $compiler);
 	$compiler->registerComponent(\Bottledcode\SwytchFramework\Tests\SimpleApp\App::class);
 	$compiler->registerComponent(\Bottledcode\SwytchFramework\Tests\SimpleApp\TodoItem::class);
 	$compiler->registerComponent(\Bottledcode\SwytchFramework\Tests\SimpleApp\Label::class);

--- a/tests/RouterApp/Index.php
+++ b/tests/RouterApp/Index.php
@@ -1,27 +1,50 @@
 <?php
 
-use Bottledcode\SwytchFramework\Router\Attributes\Route;
-use Bottledcode\SwytchFramework\Router\Method;
 use Bottledcode\SwytchFramework\Template\Attributes\Component;
 
 #[Component('Index')]
-class RouterAppIndex {
-	public function render() {
-		/** @lang HTML */
-		return <<<HTML
-<!DOCTYPE html>
-<html lang="en">
-	<head>
-		<title>Index</title>
-	</head>
-<body>
-	<Route path="/" method="GET" render="<Test />" />
-	<Route path="/test/:stuff" method="GET" render="<Test id='blah' stuff='{{:stuff}}' />" />
-	<DefaultRoute render="<Test />" />
-</body>
-</html>
-HTML;
+class RouterAppIndex
+{
+	use \Bottledcode\SwytchFramework\Template\Traits\RegularPHP;
+
+	public function __construct()
+	{
 	}
 
-	public function __construct() {}
+	public function render()
+	{
+		$this->begin();
+		?>
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <title>Index</title>
+        </head>
+        <body>
+        <Route path="/test/:stuff" method="GET">
+            <Test id="blah" stuff="{{:stuff}}" nesting="3"></Test>
+        </Route>
+        <Route path="/" method="GET">
+            <p>Test</p>
+            <Test></Test>
+        </Route>
+        <Route path="/script">
+            <script>
+                console.log({{document.location.href}})
+            </script>
+        </Route>
+        <route path="/form">
+            <form hx-post="/somewhere">
+                <input type="text" name="test" value="test">
+            </form>
+        </route>
+        <DefaultRoute>
+            <Test></Test>
+        </DefaultRoute>
+        </body>
+        </html>
+
+		<?php
+		return $this->end();
+	}
 }

--- a/tests/RouterApp/Index.php
+++ b/tests/RouterApp/Index.php
@@ -22,7 +22,7 @@ class RouterAppIndex
         </head>
         <body>
         <Route path="/test/:stuff" method="GET">
-            <Test id="blah" stuff="{{:stuff}}" nesting="3"></Test>
+            <Test stuff="{{:stuff}}" nesting="3"></Test>
         </Route>
         <Route path="/" method="GET">
             <p>Test</p>
@@ -34,9 +34,7 @@ class RouterAppIndex
             </script>
         </Route>
         <route path="/form">
-            <form hx-post="/somewhere">
-                <input type="text" name="test" value="test">
-            </form>
+            <test nesting="0"></test>
         </route>
         <DefaultRoute>
             <Test></Test>

--- a/tests/RouterApp/Test.php
+++ b/tests/RouterApp/Test.php
@@ -2,25 +2,33 @@
 
 use Bottledcode\SwytchFramework\Template\Attributes\Component;
 use Bottledcode\SwytchFramework\Template\Traits\Htmx;
+use Bottledcode\SwytchFramework\Template\Traits\RegularPHP;
 
 #[Component('Test')]
-class Test {
+class Test
+{
 	use Htmx;
+	use RegularPHP;
 
-	public function onKeyUp(string $event): void {
+	public function onKeyUp(string $event): void
+	{
 	}
 
-	public function render(string $stuff = '') {
-		$script = "alert('Hello World!')";
-		$style = 'h1 { color: red; }';
-		return <<<HTML
-<div>
-	<h1>{{$stuff}}</h1>
-	<input />
-	<script>
-	{{$script}}
-	</script>
-</div>
-HTML;
+	public function render(int $stuff = 5, int $nesting = 0)
+	{
+		if ($nesting === 0) {
+			return '<p>Test</p>';
+		}
+
+		$this->begin();
+		?>
+
+        <div>
+            <h1>{<?= $stuff ?>}</h1>
+            <test stuff="{<?= $stuff + 1 ?>}" nesting="{<?= $nesting - 1 ?>}"></test>
+        </div>
+
+		<?php
+		return $this->end();
 	}
 }

--- a/tests/RouterApp/Test.php
+++ b/tests/RouterApp/Test.php
@@ -17,7 +17,13 @@ class Test
 	public function render(int $stuff = 5, int $nesting = 0)
 	{
 		if ($nesting === 0) {
-			return '<p>Test</p>';
+			$this->begin();
+			?>
+            <form hx-post="/somewhere">
+                <input type="text" name="test" value="test">
+            </form>
+			<?php
+			return $this->end();
 		}
 
 		$this->begin();

--- a/tests/RouterApp/Test.php
+++ b/tests/RouterApp/Test.php
@@ -19,9 +19,7 @@ class Test
 		if ($nesting === 0) {
 			$this->begin();
 			?>
-            <form hx-post="/somewhere">
-                <input type="text" name="test" value="test">
-            </form>
+            <div>hi</div>
 			<?php
 			return $this->end();
 		}

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -52,9 +52,9 @@ it('can render variables', function () {
 	$compiler->registerComponent(Test::class);
 	$compiler->registerComponent(Route::class);
 	$compiler->registerComponent(DefaultRoute::class);
-	$_SERVER['REQUEST_METHOD'] = Method::GET->value;
-	$_SERVER['REQUEST_URI'] = '/test/123';
-	$container->set(Route::class, new Route());
+	$request = (new \Nyholm\Psr7\Factory\Psr17Factory())->createServerRequest(Method::GET->value, '/test/123');
+	$container->set(\Psr\Http\Message\ServerRequestInterface::class, $request);
+	$container->set(Route::class, new Route($request));
 	Route::reset();
 
 	$app = $compiler->compileComponent(RouterAppIndex::class);

--- a/tests/SimpleApp/App.php
+++ b/tests/SimpleApp/App.php
@@ -13,7 +13,7 @@ class App {
 		return <<<HTML
 <div>
 Your name is {{$name}}.
-<todoItem id="stable" diamond />
+<todoItem id="stable" diamond ></todoItem>
 <blah:label id="labeltest" for="stable">
 This is a label
 </blah:label>

--- a/tests/SimpleApp/Index.php
+++ b/tests/SimpleApp/Index.php
@@ -19,7 +19,7 @@ class Index
 <title>{{$title}}</title>
 </head>
 <body>
-<TestApp id="app" name="{{$name}}" />
+<TestApp id="app" name="{{$name}}"></TestApp>
 </body>
 </html>
 HTML;

--- a/tests/SimpleApp/Label.php
+++ b/tests/SimpleApp/Label.php
@@ -15,7 +15,7 @@ class Label
 		$this->begin();
 		?>
         <label for="<?= $for ?>">
-            <children/>
+            <children></children>
         </label>
 		<?php
 		return $this->end();

--- a/tests/__snapshots__/RouterTest__it_can_be_used_to_route_to_other_components_based_on_request__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_be_used_to_route_to_other_components_based_on_request__1.html
@@ -1,11 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-		<title>Index</title>
-	</head>
-<body>
-	<route><test></test></route>
-	<route></route>
-	<defaultroute></defaultroute>
-</body>
-</html>
+            <title>Index</title>
+        </head>
+        <body>
+        <route></route>
+        <route>
+            <p>Test</p>
+            <test></test>
+        </route>
+        <route></route>
+        <route></route>
+        <defaultroute></defaultroute>
+        </body>
+        
+
+		</html>

--- a/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
@@ -8,10 +8,7 @@
         <route></route>
         <route></route>
         <route>
-            <test id="c9f0f895">            <form hx-post="/somewhere">
-<input type="hidden" name="csrf_token" value="WZSBUTomVbGO0hDU9xWwiBMw0BN/jmuyV/v0zLRRmJM="><input type="hidden" name="state_hash" value="3c235e85dcd2d85f383a06f15cb3985a2c6bc6585393d3fc492356fbf3ebf743"><input type="hidden" name="state" value="eyJuZXN0aW5nIjoiMCJ9"><input type="hidden" name="target_id" value="c9f0f895">
-                <input type="text" name="test" value="test">
-            </form>
+            <test id="c9f0f895">            <div>hi</div>
 			</test>
         </route>
         <defaultroute></defaultroute>

--- a/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
@@ -8,9 +8,11 @@
         <route></route>
         <route></route>
         <route>
-            <form hx-post="/somewhere">
+            <test id="c9f0f895">            <form hx-post="/somewhere">
+<input type="hidden" name="csrf_token" value="WZSBUTomVbGO0hDU9xWwiBMw0BN/jmuyV/v0zLRRmJM="><input type="hidden" name="state_hash" value="3c235e85dcd2d85f383a06f15cb3985a2c6bc6585393d3fc492356fbf3ebf743"><input type="hidden" name="state" value="eyJuZXN0aW5nIjoiMCJ9"><input type="hidden" name="target_id" value="c9f0f895">
                 <input type="text" name="test" value="test">
             </form>
+			</test>
         </route>
         <defaultroute></defaultroute>
         </body>

--- a/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_an_htmx_trigger__1.html
@@ -8,7 +8,7 @@
         <route></route>
         <route></route>
         <route>
-            <test id="c9f0f895">            <div>hi</div>
+            <test id="cc9f0f89">            <div>hi</div>
 			</test>
         </route>
         <defaultroute></defaultroute>

--- a/tests/__snapshots__/RouterTest__it_can_render_default_route__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_default_route__1.html
@@ -1,11 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-		<title>Index</title>
-	</head>
-<body>
-	<route></route>
-	<route></route>
-	<defaultroute><test></test></defaultroute>
-</body>
-</html>
+            <title>Index</title>
+        </head>
+        <body>
+        <route></route>
+        <route></route>
+        <route></route>
+        <route></route>
+        <defaultroute>
+            <test></test>
+        </defaultroute>
+        </body>
+        
+
+		</html>

--- a/tests/__snapshots__/RouterTest__it_can_render_script_tags__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_script_tags__1.html
@@ -6,12 +6,12 @@
         <body>
         <route></route>
         <route></route>
-        <route></route>
         <route>
-            <form hx-post="/somewhere">
-                <input type="text" name="test" value="test">
-            </form>
+            <script>
+                console.log({document.location.href})
+            </script>
         </route>
+        <route></route>
         <defaultroute></defaultroute>
         </body>
         

--- a/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
@@ -5,16 +5,16 @@
         </head>
         <body>
         <route>
-            <test id="a87ff679">
+            <test id="ca87ff67">
         <div>
             <h1>123</h1>
-            <test id="e4da3b7f">
+            <test id="ce4da3b7">
         <div>
             <h1>124</h1>
-            <test id="1679091c">
+            <test id="c1679091">
         <div>
             <h1>125</h1>
-            <test id="8f14e45f">            <div>hi</div>
+            <test id="c8f14e45">            <div>hi</div>
 			</test>
         </div>
 

--- a/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
@@ -5,16 +5,20 @@
         </head>
         <body>
         <route>
-            <test id="blah">
-        <div>
-            <h1>123</h1>
             <test id="a87ff679">
         <div>
-            <h1>124</h1>
+            <h1>123</h1>
             <test id="e4da3b7f">
         <div>
+            <h1>124</h1>
+            <test id="1679091c">
+        <div>
             <h1>125</h1>
-            <test id="1679091c"><p>Test</p></test>
+            <test id="8f14e45f">            <form hx-post="/somewhere">
+<input type="hidden" name="csrf_token" value="pJZ5NuwGplkgiTqRARMPMDLPMoxFUvFQNB6MgWuAGec="><input type="hidden" name="state_hash" value="A"><input type="hidden" name="state" value="eyJzdHVmZiI6Il9fQkxPQl9fN19fIiwibmVzdGluZyI6Il9fQkxPQl9fOF9fIn0="><input type="hidden" name="target_id" value="8f14e45f">
+                <input type="text" name="test" value="test">
+            </form>
+			</test>
         </div>
 
 		</test>

--- a/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
@@ -14,10 +14,7 @@
             <test id="1679091c">
         <div>
             <h1>125</h1>
-            <test id="8f14e45f">            <form hx-post="/somewhere">
-<input type="hidden" name="csrf_token" value="pJZ5NuwGplkgiTqRARMPMDLPMoxFUvFQNB6MgWuAGec="><input type="hidden" name="state_hash" value="A"><input type="hidden" name="state" value="eyJzdHVmZiI6Il9fQkxPQl9fN19fIiwibmVzdGluZyI6Il9fQkxPQl9fOF9fIn0="><input type="hidden" name="target_id" value="8f14e45f">
-                <input type="text" name="test" value="test">
-            </form>
+            <test id="8f14e45f">            <div>hi</div>
 			</test>
         </div>
 

--- a/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
+++ b/tests/__snapshots__/RouterTest__it_can_render_variables__1.html
@@ -1,17 +1,35 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-		<title>Index</title>
-	</head>
-<body>
-	<route></route>
-	<route><test id="blah"><div>
-	<h1>123</h1>
-	<input>
-	<script>
-	alert\x28\x27Hello\x20World\x21\x27\x29
-	</script>
-</div></test></route>
-	<defaultroute></defaultroute>
-</body>
-</html>
+            <title>Index</title>
+        </head>
+        <body>
+        <route>
+            <test id="blah">
+        <div>
+            <h1>123</h1>
+            <test id="a87ff679">
+        <div>
+            <h1>124</h1>
+            <test id="e4da3b7f">
+        <div>
+            <h1>125</h1>
+            <test id="1679091c"><p>Test</p></test>
+        </div>
+
+		</test>
+        </div>
+
+		</test>
+        </div>
+
+		</test>
+        </route>
+        <route></route>
+        <route></route>
+        <route></route>
+        <defaultroute></defaultroute>
+        </body>
+        
+
+		</html>


### PR DESCRIPTION
Currently, the router component requires the SAPI APIs (aka, `$_SERVER` and friends) to work because it doesn't have access to the `ServerRequestInterface` object.

This PR will:

1. Add the `ServerRequestInterface` to the container after preprocessing.
2. Update the router component to use this.