### PR TITLE
fix delayed rendering

### DIFF
--- a/src/Template/LazyTreeBuilder.php
+++ b/src/Template/LazyTreeBuilder.php
@@ -137,9 +137,12 @@ class LazyTreeBuilder extends DOMTreeBuilder
 				$attributes
 			);
 
-			// in a weird quirk of php, this results in appending a new array to the delay stack and they are the same variable.
-			$this->delayStackPointer = &$this->delayStack[];
-			$this->delayStackPointer = [];
+			// only count children we are actually rendering
+			if(count($this->componentStack) === 1) {
+				// in a weird quirk of php, this results in appending a new array to the delay stack and they are the same variable.
+				$this->delayStackPointer = &$this->delayStack[];
+				$this->delayStackPointer = [];
+			}
 
 			// consume children
 			$this->childParents[] = $this->current;


### PR DESCRIPTION
Fixes an issue when sibling-child components wouldn't be rendered due to a new stack being created on every component entry, but only popped off the stack after a top-level component was rendered. This change pushes a new delayed rendering stack only when we enter a top-level component.