### PR TITLE
cache: handle private separately

### DIFF
--- a/src/Cache/CachePublic.php
+++ b/src/Cache/CachePublic.php
@@ -9,7 +9,7 @@ readonly class CachePublic extends AbstractCache
 {
 	public function tokenize(Tokenizer $tokenizer): Tokenizer
 	{
-		if (!$tokenizer->public) {
+		if ($tokenizer->private) {
 			return $tokenizer;
 		}
 

--- a/src/Cache/Control/Tokenizer.php
+++ b/src/Cache/Control/Tokenizer.php
@@ -40,7 +40,12 @@ readonly class Tokenizer
 		/**
 		 * @var bool indicates that any caches of any kind (public or shared) should not store this response.
 		 */
-		public bool $public = true,
+		public bool $public = false,
+
+		/**
+		 * @var bool indicates that a public cache should not cache this
+		 */
+		public bool $private = false,
 
 		/**
 		 * @var bool indicates that the response will not be updated while it's fresh.
@@ -68,6 +73,7 @@ readonly class Tokenizer
 		bool|null $proxyRevalidate = null,
 		bool|null $noStore = null,
 		bool|null $public = null,
+		bool|null $private = null,
 		bool|null $immutable = null,
 		int|null|false $staleWhileRevalidating = false,
 		int|null|false $staleIfError = false,
@@ -80,6 +86,7 @@ readonly class Tokenizer
 			proxyRevalidate: $this->withBool($this->proxyRevalidate, $proxyRevalidate),
 			noStore: $this->withBool($this->noStore, $noStore),
 			public: $this->withBool($this->public, $public),
+			private: $this->withBool($this->private, $private),
 			immutable: $this->withBool($this->immutable, $immutable),
 			staleWhileRevalidating: $this->withInt($this->staleWhileRevalidating, $staleWhileRevalidating),
 			staleIfError: $this->withInt($this->staleIfError, $staleIfError),
@@ -99,7 +106,8 @@ readonly class Tokenizer
 	public function render(): string
 	{
 		$header = [
-			$this->public ? 'public' : 'private',
+			...$this->header($this->private, 'private'),
+			...$this->header($this->public, 'public'),
 			...$this->header($this->maxAge, "max-age=$this->maxAge"),
 			...$this->header($this->sMaxAge, "s-maxage=$this->sMaxAge"),
 			...$this->header($this->noCache, "no-cache"),

--- a/src/Cache/NeverCache.php
+++ b/src/Cache/NeverCache.php
@@ -18,9 +18,10 @@ readonly class NeverCache extends AbstractCache
 			proxyRevalidate: false,
 			noStore: true,
 			public: false,
+			private: true,
 			immutable: false,
 			staleWhileRevalidating: null,
-			staleIfError: null
+			staleIfError: null,
 		);
 	}
 }

--- a/src/Cache/UserSpecific.php
+++ b/src/Cache/UserSpecific.php
@@ -12,6 +12,6 @@ readonly class UserSpecific extends AbstractCache
 {
 	public function tokenize(Tokenizer $tokenizer): Tokenizer
 	{
-		return $tokenizer->with(public: false);
+		return $tokenizer->with(public: false, private: true);
 	}
 }

--- a/tests/CacheTest.php
+++ b/tests/CacheTest.php
@@ -21,13 +21,15 @@ function render(Tokenizer $tokenizer, AbstractCache ...$directives): string
 
 it('can describe a simple public cache', function () {
 	$tokenizer = new Tokenizer();
-	expect(render($tokenizer))->toBe('public');
+	$directives[] = new CachePublic();
+	expect(render($tokenizer, ...$directives))->toBe('public');
 });
 
 it('can handle max age rules', function () {
 	$tokenizer = new Tokenizer();
 
 	$directives[] = new NeverChanges();
+	$directives[] = new CachePublic();
 	expect(render($tokenizer, ...$directives))->toBe("public max-age=604800 immutable");
 
 	$directives[] = new MaxAge(3000);
@@ -54,6 +56,7 @@ it('can handle revalidation rules', function () {
 	$tokenizer = new Tokenizer();
 
 	$directives[] = new NeverChanges();
+	$directives[] = new CachePublic();
 	expect(render($tokenizer, ...$directives))->toBe("public max-age=604800 immutable");
 	$directives[] = new Revalidate(RevalidationEnum::AfterError, 300);
 	expect(render($tokenizer, ...$directives))->toBe("public stale-if-error=300");
@@ -95,4 +98,10 @@ it('can handle public/private', function () {
 
 	$directives[] = new CachePublic();
 	expect(render($tokenizer, ...$directives))->toBe("private");
+});
+
+it('renders nothing when empty', function() {
+	$tokenizer = new Tokenizer();
+
+	expect(render($tokenizer))->toBe('');
 });


### PR DESCRIPTION
Don't send just a `Cache-Control: public` header if caching isn't configured.